### PR TITLE
Implementation of algorithm one from the paper

### DIFF
--- a/src/omniglot/main.py
+++ b/src/omniglot/main.py
@@ -74,7 +74,7 @@ parser.add_argument('--no_batch_norm', action='store_true',
                     help='Turn off batch normalization')
 
 parser.add_argument('--meta_model', type=str, default='warp_leap',
-                    help='Meta-learner [warp_leap, leap, reptile,'
+                    help='Meta-learner [warp_leap, warp_online, leap, reptile,'
                          'maml, fomaml, ft, no]')
 parser.add_argument('--inner_opt', type=str, default='sgd',
                     help='Optimizer in inner (task) loop: SGD or Adam')

--- a/src/omniglot/model.py
+++ b/src/omniglot/model.py
@@ -3,7 +3,8 @@ https://github.com/amzn/metalearn-leap
 """
 import torch.nn as nn
 from wrapper import (WarpGradWrapper, LeapWrapper, MAMLWrapper, NoWrapper,
-                      FtWrapper, FOMAMLWrapper, ReptileWrapper)
+                     FtWrapper, FOMAMLWrapper, ReptileWrapper,
+                     WarpGradOnlineWrapper)
 
 NUM_CLASSES = 50
 ACT_FUNS = {
@@ -43,14 +44,25 @@ def get_model(args, criterion):
         print(model)
 
     if "warp" in args.meta_model.lower():
-        return WarpGradWrapper(
-            model,
-            args.inner_opt,
-            args.outer_opt,
-            args.inner_kwargs,
-            args.outer_kwargs,
-            args.meta_kwargs,
-            criterion)
+        # this uses online algorithm wrapper
+        if "online" in args.meta_model.lower():
+            return WarpGradOnlineWrapper(
+                model,
+                args.inner_opt,
+                args.outer_opt,
+                args.inner_kwargs,
+                args.outer_kwargs,
+                args.meta_kwargs,
+                criterion)
+        else:
+            return WarpGradWrapper(
+                model,
+                args.inner_opt,
+                args.outer_opt,
+                args.inner_kwargs,
+                args.outer_kwargs,
+                args.meta_kwargs,
+                criterion)
 
     if args.meta_model.lower() == 'leap':
         return LeapWrapper(

--- a/src/omniglot/model.py
+++ b/src/omniglot/model.py
@@ -1,6 +1,7 @@
 """Base Omniglot models. Based on original implementation:
 https://github.com/amzn/metalearn-leap
 """
+import torch
 import torch.nn as nn
 from wrapper import (WarpGradWrapper, LeapWrapper, MAMLWrapper, NoWrapper,
                      FtWrapper, FOMAMLWrapper, ReptileWrapper,
@@ -491,7 +492,6 @@ class WarpedOmniConv(nn.Module):
         """Reset stats for new task"""
         # Reset head if multi-headed, otherwise null-op
         self.head.reset_parameters()
-
         # Reset BN running stats
         for m in self.modules():
             if hasattr(m, 'reset_running_stats'):

--- a/src/warpgrad/warpgrad/__init__.py
+++ b/src/warpgrad/warpgrad/__init__.py
@@ -1,3 +1,3 @@
 from .warpgrad import Warp, OptimizerParameters, ReplayBuffer
-from .updaters import DualUpdater
+from .updaters import DualUpdater, SimpleUpdater
 from .optim import SGD, Adam

--- a/src/warpgrad/warpgrad/updaters.py
+++ b/src/warpgrad/warpgrad/updaters.py
@@ -59,7 +59,7 @@ class SimpleUpdater:
         # init_objective = INIT_OBJECTIVES[self.init_objective]
         # init_objective(model.named_init_parameters(suffix=None),
         #                params, self.norm, self.bsz, step_fn)
-
+        pass
 
 class DualUpdater:
     """Implements the WarpGrad meta-objective.

--- a/src/warpgrad/warpgrad/warpgrad.py
+++ b/src/warpgrad/warpgrad/warpgrad.py
@@ -467,7 +467,8 @@ class Warp(Parameters):
 
     def clear(self):
         """Clears parameter trajectory buffer."""
-        self.buffer.clear()
+        if self.buffer is not None:
+            self.buffer.clear()
 
     def collect(self):
         """Switch on task parameter collection in buffer."""


### PR DESCRIPTION
This PR is the initial effort for implementing Algorithm one for online learning using Warpgrad. I started analysing the implementation of algorithm 2. Since online learning algorithm does not require to store datapoints and model states in the buffer, I have reused [step](https://github.com/flennerhag/warpgrad/blob/d9ef72af10eec62ae92bc24595cb1a4a0207e319/src/warpgrad/warpgrad/utils.py#L58-L103) function from `warpgrad.utils` inside inner training loop.

Summary of changes:

- New wrapper for online algorithm added. This reuses functions from `warpgrad.utils`
- Simple updater class is added. However, it works only as placeholder and does nothing in the backward pass call. I am not sure if `leap` based initialization should be applied also for online learning.
- `step` function is called inside `run_batches` function of the wrapper class for each `k` times of inner update.
- Generated losses are accumulated using `meta_loss` property of wrapper class.